### PR TITLE
read_vc(), write_vc(), rm_data(): default root

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,10 @@ Authors@R: c(
     email = "thierry.onkelinx@inbo.be", 
     comment = c(ORCID = "0000-0001-8804-4216")),
   person(
+    "Floris", "Vanderhaeghe", role = "ctb", 
+    email = "floris.vanderhaeghe@inbo.be", 
+    comment = c(ORCID = "0000-0002-6378-6229")),
+  person(
     "Research Institute for Nature and Forest",
     role = c("cph", "fnd"), email = "info@inbo.be"))
 Description: Make versioning of data.frame easy and efficient using git repositories.

--- a/R/read_vc.R
+++ b/R/read_vc.R
@@ -20,7 +20,7 @@ setMethod(
   signature = signature(root = "ANY"),
   definition = function(file, root){
     if (missing(root)) {
-      read_vc(file = file, root = ".")
+      return(read_vc(file = file, root = "."))
     }
     stop("a 'root' of class ", class(root), " is not supported")
   }

--- a/R/read_vc.R
+++ b/R/read_vc.R
@@ -8,7 +8,7 @@
 #' @importFrom methods setGeneric
 setGeneric(
   name = "read_vc",
-  def = function(file, root){
+  def = function(file, root = "."){
     standardGeneric("read_vc") # nocov
   }
 )

--- a/R/read_vc.R
+++ b/R/read_vc.R
@@ -20,7 +20,7 @@ setMethod(
   signature = signature(root = "ANY"),
   definition = function(file, root){
     if (missing(root)) {
-      stop("'root' is missing")
+      read_vc(file = file, root = ".")
     }
     stop("a 'root' of class ", class(root), " is not supported")
   }

--- a/R/read_vc.R
+++ b/R/read_vc.R
@@ -15,6 +15,19 @@ setGeneric(
 
 #' @rdname read_vc
 #' @importFrom methods setMethod
+setMethod(
+  f = "read_vc",
+  signature = signature(root = "ANY"),
+  definition = function(file, root){
+    if (missing(root)) {
+      stop("'root' is missing")
+    }
+    stop("a 'root' of class ", class(root), " is not supported")
+  }
+)
+
+#' @rdname read_vc
+#' @importFrom methods setMethod
 #' @importFrom assertthat assert_that is.string
 #' @importFrom readr read_tsv
 #' @importFrom utils head

--- a/R/recent_commit.R
+++ b/R/recent_commit.R
@@ -1,6 +1,7 @@
 #' Most recent file change
 #' Retrieve the most recent commit in which a file or data object existed.
 #' @inheritParams write_vc
+#' @param root The root of a project. Can be a file path or a `git-repository`
 #' @param data refers file to a file (FALSE) or a data object (TRUE). Defaults
 #' to FALSE
 #' @return a `data.frame` with `commit`, `author` and `when` for the most recent

--- a/R/rm_data.R
+++ b/R/rm_data.R
@@ -15,7 +15,8 @@
 setGeneric(
   name = "rm_data",
   def = function(
-    root = ".", path = NULL, type = c("tsv", "yml", "both"), recursive = TRUE, ...
+    root = ".", path = NULL, type = c("tsv", "yml", "both"), recursive = TRUE,
+    ...
   ){
     standardGeneric("rm_data") # nocov
   }
@@ -30,11 +31,11 @@ setMethod(
     root, path = NULL, type = c("tsv", "yml", "both"), recursive = TRUE, ...
   ){
     if (missing(root)) {
-      return(rm_data(root = ".",
-                     path = NULL,
-                     type = c("tsv", "yml", "both"),
-                     recursive = TRUE,
-                     ...))
+      return(
+        rm_data(
+          root = ".", path = path, type = type, recursive = recursive, ...
+        )
+      )
     }
     stop("a 'root' of class ", class(root), " is not supported")
   }

--- a/R/rm_data.R
+++ b/R/rm_data.R
@@ -15,9 +15,28 @@
 setGeneric(
   name = "rm_data",
   def = function(
-    root, path = NULL, type = c("tsv", "yml", "both"), recursive = TRUE, ...
+    root = ".", path = NULL, type = c("tsv", "yml", "both"), recursive = TRUE, ...
   ){
     standardGeneric("rm_data") # nocov
+  }
+)
+
+#' @rdname rm_data
+#' @importFrom methods setMethod
+setMethod(
+  f = "rm_data",
+  signature = signature(root = "ANY"),
+  definition = function(
+    root, path = NULL, type = c("tsv", "yml", "both"), recursive = TRUE, ...
+  ){
+    if (missing(root)) {
+      return(rm_data(root = ".",
+                     path = NULL,
+                     type = c("tsv", "yml", "both"),
+                     recursive = TRUE,
+                     ...))
+    }
+    stop("a 'root' of class ", class(root), " is not supported")
   }
 )
 

--- a/R/write_vc.R
+++ b/R/write_vc.R
@@ -24,7 +24,7 @@
 setGeneric(
   name = "write_vc",
   def = function(
-    x, file, root, sorting, override = FALSE, optimize = TRUE, ...
+    x, file, root = ".", sorting, override = FALSE, optimize = TRUE, ...
   ){
     standardGeneric("write_vc") # nocov
   }
@@ -39,7 +39,13 @@ setMethod(
     x, file, root, sorting, override = FALSE, optimize = TRUE, ...
   ){
     if (missing(root)) {
-      stop("'root' is missing")
+      return(write_vc(x = x,
+                      file = file,
+                      root = ".",
+                      sorting = sorting,
+                      override = FALSE,
+                      optimize = TRUE,
+                      ...))
     }
     stop("a 'root' of class ", class(root), " is not supported")
   }

--- a/R/write_vc.R
+++ b/R/write_vc.R
@@ -5,7 +5,8 @@
 #' @param x the `data.frame
 #' @param file the name of the file without file extension. Can include a
 #' relative path. It is relative to the `root`.
-#' @param root The root of a project. Can be a file path or a `git-repository`
+#' @param root The root of a project. Can be a file path or a `git-repository`.
+#' Defaults to the current working directory (".").
 #' @param sorting a vector of column names defining which columns to use for
 #' sorting \code{x} and in what order to use them. Only required when writing
 #' new metadata.

--- a/R/write_vc.R
+++ b/R/write_vc.R
@@ -40,13 +40,12 @@ setMethod(
     x, file, root, sorting, override = FALSE, optimize = TRUE, ...
   ){
     if (missing(root)) {
-      return(write_vc(x = x,
-                      file = file,
-                      root = ".",
-                      sorting = sorting,
-                      override = FALSE,
-                      optimize = TRUE,
-                      ...))
+      return(
+        write_vc(
+          x = x, file = file, root = ".", sorting = sorting,
+          override = override, optimize = optimize, ...
+        )
+      )
     }
     stop("a 'root' of class ", class(root), " is not supported")
   }

--- a/codemeta.json
+++ b/codemeta.json
@@ -14,10 +14,10 @@
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 3.5.1 (2018-07-02)",
+  "runtimePlatform": "R version 3.5.2 (2018-12-20)",
   "author": [
     {
       "@type": "Person",
@@ -139,7 +139,7 @@
     }
   ],
   "readme": "https://github.com/inbo/git2rdata/blob/master/README.md",
-  "fileSize": "36.79KB",
+  "fileSize": "69.924KB",
   "contIntegration": [
     "https://travis-ci.org/inbo/git2rdata",
     "https://ci.appveyor.com/project/ThierryO/git2rdata/branch/master",
@@ -154,5 +154,14 @@
     "version-control",
     "reproducible-research"
   ],
-  "relatedLink": "https://doi.org/10.5281/zenodo.1485309"
+  "relatedLink": "https://doi.org/10.5281/zenodo.1485309",
+  "contributor": [
+    {
+      "@type": "Person",
+      "givenName": "Floris",
+      "familyName": "Vanderhaeghe",
+      "email": "floris.vanderhaeghe@inbo.be",
+      "@id": "https://orcid.org/0000-0002-6378-6229"
+    }
+  ]
 }

--- a/man/git2rdata-package.Rd
+++ b/man/git2rdata-package.Rd
@@ -22,6 +22,7 @@ Useful links:
 
 Other contributors:
 \itemize{
+  \item Floris Vanderhaeghe \email{floris.vanderhaeghe@inbo.be} (0000-0002-6378-6229) [contributor]
   \item Research Institute for Nature and Forest \email{info@inbo.be} [copyright holder, funder]
 }
 

--- a/man/read_vc.Rd
+++ b/man/read_vc.Rd
@@ -20,7 +20,8 @@ read_vc(file, root = ".")
 \item{file}{the name of the file without file extension. Can include a
 relative path. It is relative to the \code{root}.}
 
-\item{root}{The root of a project. Can be a file path or a \code{git-repository}}
+\item{root}{The root of a project. Can be a file path or a \code{git-repository}.
+Defaults to the current working directory (".").}
 }
 \value{
 The \code{data.frame}

--- a/man/read_vc.Rd
+++ b/man/read_vc.Rd
@@ -3,11 +3,14 @@
 \docType{methods}
 \name{read_vc}
 \alias{read_vc}
+\alias{read_vc,ANY,ANY-method}
 \alias{read_vc,ANY,character-method}
 \alias{read_vc,ANY,git_repository-method}
 \title{Read a \code{data.frame} from a repository}
 \usage{
 read_vc(file, root)
+
+\S4method{read_vc}{ANY,ANY}(file, root)
 
 \S4method{read_vc}{ANY,character}(file, root)
 

--- a/man/read_vc.Rd
+++ b/man/read_vc.Rd
@@ -8,13 +8,13 @@
 \alias{read_vc,ANY,git_repository-method}
 \title{Read a \code{data.frame} from a repository}
 \usage{
-read_vc(file, root)
+read_vc(file, root = ".")
 
-\S4method{read_vc}{ANY,ANY}(file, root)
+\S4method{read_vc}{ANY,ANY}(file, root = ".")
 
-\S4method{read_vc}{ANY,character}(file, root)
+\S4method{read_vc}{ANY,character}(file, root = ".")
 
-\S4method{read_vc}{ANY,git_repository}(file, root)
+\S4method{read_vc}{ANY,git_repository}(file, root = ".")
 }
 \arguments{
 \item{file}{the name of the file without file extension. Can include a

--- a/man/rm_data.Rd
+++ b/man/rm_data.Rd
@@ -3,21 +3,26 @@
 \docType{methods}
 \name{rm_data}
 \alias{rm_data}
+\alias{rm_data,ANY-method}
 \alias{rm_data,character-method}
 \alias{rm_data,git_repository-method}
 \title{Remove data files}
 \usage{
-rm_data(root, path = NULL, type = c("tsv", "yml", "both"),
+rm_data(root = ".", path = NULL, type = c("tsv", "yml", "both"),
   recursive = TRUE, ...)
 
-\S4method{rm_data}{character}(root, path = NULL, type = c("tsv", "yml",
-  "both"), recursive = TRUE, ...)
+\S4method{rm_data}{ANY}(root = ".", path = NULL, type = c("tsv",
+  "yml", "both"), recursive = TRUE, ...)
+
+\S4method{rm_data}{character}(root = ".", path = NULL,
+  type = c("tsv", "yml", "both"), recursive = TRUE, ...)
 
 \S4method{rm_data}{git_repository}(root, path = NULL, type = c("tsv",
   "yml", "both"), recursive = TRUE, ..., stage = FALSE)
 }
 \arguments{
-\item{root}{The root of a project. Can be a file path or a \code{git-repository}}
+\item{root}{The root of a project. Can be a file path or a \code{git-repository}.
+Defaults to the current working directory (".").}
 
 \item{path}{the directory in which to clean all the data files}
 

--- a/man/write_vc.Rd
+++ b/man/write_vc.Rd
@@ -27,7 +27,8 @@ write_vc(x, file, root = ".", sorting, override = FALSE,
 \item{file}{the name of the file without file extension. Can include a
 relative path. It is relative to the \code{root}.}
 
-\item{root}{The root of a project. Can be a file path or a \code{git-repository}}
+\item{root}{The root of a project. Can be a file path or a \code{git-repository}.
+Defaults to the current working directory (".").}
 
 \item{sorting}{a vector of column names defining which columns to use for
 sorting \code{x} and in what order to use them. Only required when writing

--- a/man/write_vc.Rd
+++ b/man/write_vc.Rd
@@ -8,13 +8,13 @@
 \alias{write_vc,ANY,ANY,git_repository-method}
 \title{Write a \code{data.frame} to a git repository}
 \usage{
-write_vc(x, file, root, sorting, override = FALSE, optimize = TRUE,
-  ...)
+write_vc(x, file, root = ".", sorting, override = FALSE,
+  optimize = TRUE, ...)
 
-\S4method{write_vc}{ANY,ANY,ANY}(x, file, root, sorting,
+\S4method{write_vc}{ANY,ANY,ANY}(x, file, root = ".", sorting,
   override = FALSE, optimize = TRUE, ...)
 
-\S4method{write_vc}{ANY,ANY,character}(x, file, root, sorting,
+\S4method{write_vc}{ANY,ANY,character}(x, file, root = ".", sorting,
   override = FALSE, optimize = TRUE, ...)
 
 \S4method{write_vc}{ANY,ANY,git_repository}(x, file, root, sorting,

--- a/tests/testthat/test_a_basics.R
+++ b/tests/testthat/test_a_basics.R
@@ -1,5 +1,6 @@
 context("write_vc() and read_vc() on a file system")
 expect_error(write_vc(root = 1), "a 'root' of class numeric is not supported")
+expect_error(read_vc(root = 1), "a 'root' of class numeric is not supported")
 output <- write_vc(x = test_data,
                    file = "test.txt",
                    sorting = "test_Date")

--- a/tests/testthat/test_a_basics.R
+++ b/tests/testthat/test_a_basics.R
@@ -4,6 +4,11 @@ output <- write_vc(x = test_data,
                    file = "test.txt",
                    sorting = "test_Date")
 expect_true(all(file.exists(git2rdata:::clean_data_path(".", "test"))))
+expect_equal(
+  stored <- read_vc(file = "test.xls"),
+  sorted_test_data,
+  check.attributes = FALSE
+)
 if (file.exists("test.tsv")) file.remove("test.tsv")
 if (file.exists("test.yml")) file.remove("test.yml")
 root <- tempfile(pattern = "git2rdata-basic")

--- a/tests/testthat/test_a_basics.R
+++ b/tests/testthat/test_a_basics.R
@@ -1,6 +1,11 @@
 context("write_vc() and read_vc() on a file system")
-expect_error(write_vc(), "'root' is missing")
 expect_error(write_vc(root = 1), "a 'root' of class numeric is not supported")
+output <- write_vc(x = test_data,
+                   file = "test.txt",
+                   sorting = "test_Date")
+expect_true(all(file.exists(git2rdata:::clean_data_path(".", "test"))))
+if (file.exists("test.tsv")) file.remove("test.tsv")
+if (file.exists("test.yml")) file.remove("test.yml")
 root <- tempfile(pattern = "git2rdata-basic")
 dir.create(root)
 expect_false(any(file.exists(git2rdata:::clean_data_path(root, "test"))))

--- a/tests/testthat/test_b_rm_data.R
+++ b/tests/testthat/test_b_rm_data.R
@@ -37,3 +37,14 @@ expect_identical(
   list.files(root, recursive = TRUE),
   current[-grep("^.*/.*", current)]
 )
+
+write_vc(test_data, file = "test", sorting = "test_Date")
+current <- list.files(".", recursive = TRUE)
+expect_identical(
+  rm_data(type = "both", recursive = FALSE),
+  c("test.tsv", "test.yml")
+)
+expect_identical(
+  list.files(".", recursive = TRUE),
+  current[grep("^.*/.*", current)]
+)

--- a/tests/testthat/test_b_rm_data.R
+++ b/tests/testthat/test_b_rm_data.R
@@ -1,5 +1,7 @@
 context("rm_data")
 
+expect_error(rm_data(root = 1), "a 'root' of class numeric is not supported")
+
 root <- tempfile(pattern = "git2rdata-")
 expect_error(rm_data(root), root)
 dir.create(root)


### PR DESCRIPTION
Borrowed code from `write_vc()` in order to make `read_vc()` throw an equally understandable error when the 'root' argument is not specified. Review carefully though; I'm not familiar with error handling and such.

BTW, why not setting a default for the root argument, like `"."`?