### PR TITLE
list_data(), read_vc(), write_vc(): align titles with other functions *

### DIFF
--- a/R/list_data.R
+++ b/R/list_data.R
@@ -1,4 +1,4 @@
-#' list available data objects in the repository
+#' List available data files
 #' @param root the `root` of the repository. Either a path or a `git-repository`
 #' @param path relative `path` from the `root`. Defaults to the `root`
 #' @inheritParams base::list.files

--- a/R/read_vc.R
+++ b/R/read_vc.R
@@ -1,4 +1,4 @@
-#' Read a \code{data.frame} from a repository
+#' Read a \code{data.frame}
 #' @inheritParams write_vc
 #' @return The \code{data.frame} with the file names and hashes as attributes
 #' @rdname read_vc

--- a/R/write_vc.R
+++ b/R/write_vc.R
@@ -1,4 +1,4 @@
-#' Write a \code{data.frame} to a git repository
+#' Write a \code{data.frame}
 #'
 #' This will create two files. The `".tsv"` file contains the raw data.
 #' The `".yml"` contains the meta data on the columns in YAML format.

--- a/man/list_data.Rd
+++ b/man/list_data.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/list_data.R
 \name{list_data}
 \alias{list_data}
-\title{list available data objects in the repository}
+\title{List available data files}
 \usage{
 list_data(root = ".", path = ".", recursive = TRUE)
 }
@@ -17,7 +17,7 @@ list_data(root = ".", path = ".", recursive = TRUE)
 a character vector is dataframe names, including their relative path
 }
 \description{
-list available data objects in the repository
+List available data files
 }
 \examples{
 ## on file system

--- a/man/read_vc.Rd
+++ b/man/read_vc.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/read_vc.R
 \name{read_vc}
 \alias{read_vc}
-\title{Read a \code{data.frame} from a repository}
+\title{Read a \code{data.frame}}
 \usage{
 read_vc(file, root = ".")
 }
@@ -17,7 +17,7 @@ Defaults to the current working directory (".").}
 The \code{data.frame} with the file names and hashes as attributes
 }
 \description{
-Read a \code{data.frame} from a repository
+Read a \code{data.frame}
 }
 \examples{
 ## on file system

--- a/man/write_vc.Rd
+++ b/man/write_vc.Rd
@@ -3,7 +3,7 @@
 \name{write_vc}
 \alias{write_vc}
 \alias{write_vc.git_repository}
-\title{Write a \code{data.frame} to a git repository}
+\title{Write a \code{data.frame}}
 \usage{
 write_vc(x, file, root = ".", sorting, strict = TRUE,
   optimize = TRUE, na = "NA", ...)


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

For other functions, the explicit referral to a 'repository' is not made in their title. In these functions, it is not needed either. Removing this from the title of `list_data()`, `read_vc()` and `write_vc()` makes the list of functions on the pkgdown website look more uniform.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
